### PR TITLE
fix(reader): 修复段评「点击登录」无反应 + 新增 Playwright E2E 与 CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+name: E2E
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browser (chromium)
+      run: npx playwright install --with-deps chromium
+
+    - name: Run Playwright e2e tests
+      run: npm run test:e2e
+
+    - name: Upload Playwright report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ book3
 guimi
 guimi2
 public/*.html
+
+# Playwright
+/test-results
+/playwright-report
+/blob-report
+/.playwright

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "vuetify": "^3.6.11"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vitejs/plugin-vue": "^5.0.5",
         "eslint": "^8.57.0",
         "eslint-config-standard": "^17.1.0",
@@ -565,6 +566,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -3455,6 +3472,53 @@
         "pathe": "^1.1.2"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://bnpm.byted.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -4820,6 +4884,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
       }
     },
     "@rollup/pluginutils": {
@@ -6854,6 +6927,31 @@
         "mlly": "^1.7.2",
         "pathe": "^1.1.2"
       }
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://bnpm.byted.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://bnpm.byted.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
     },
     "possible-typed-array-names": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -570,7 +570,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/@playwright/test/-/test-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3474,7 +3474,7 @@
     },
     "node_modules/playwright": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/playwright/-/playwright-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3493,7 +3493,7 @@
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3506,7 +3506,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "resolved": "https://bnpm.byted.org/fsevents/-/fsevents-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
@@ -4888,7 +4888,7 @@
     },
     "@playwright/test": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/@playwright/test/-/test-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "requires": {
@@ -6930,7 +6930,7 @@
     },
     "playwright": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/playwright/-/playwright-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "requires": {
@@ -6940,7 +6940,7 @@
       "dependencies": {
         "fsevents": {
           "version": "2.3.2",
-          "resolved": "https://bnpm.byted.org/fsevents/-/fsevents-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
           "optional": true
@@ -6949,7 +6949,7 @@
     },
     "playwright-core": {
       "version": "1.60.0",
-      "resolved": "https://bnpm.byted.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "dev": "vite",
     "build": "vite build && rm -rf dist/demo dist/talebook-template.html",
     "preview": "vite preview",
-    "lint": "eslint . --fix --ignore-path .gitignore"
+    "lint": "eslint . --fix --ignore-path .gitignore",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@mdi/font": "7.4.47",
@@ -15,6 +17,7 @@
     "vuetify": "^3.6.11"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-vue": "^5.0.5",
     "eslint": "^8.57.0",
     "eslint-config-standard": "^17.1.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,39 @@
+// Playwright 配置：针对 candle-reader 的 UI mock 测试
+// 后端接口全部通过路由拦截 mock，无需真实 talebook 服务。
+const { defineConfig, devices } = require('@playwright/test')
+
+const PORT = 5001
+const BASE_URL = `http://localhost:${PORT}`
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  // 阅读器加载 epub 较重，给单测留足时间
+  timeout: 30 * 1000,
+  expect: { timeout: 5 * 1000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    // 阅读器是移动优先（viewport-fit=cover），用手机尺寸更贴近真实场景
+    viewport: { width: 414, height: 896 },
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 414, height: 896 } },
+    },
+  ],
+
+  // 自动拉起 vite dev server
+  webServer: {
+    command: 'npm run dev',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60 * 1000,
+  },
+})

--- a/src/components/BookComments.vue
+++ b/src/components/BookComments.vue
@@ -30,7 +30,7 @@
       </template>
     </v-list>
     <v-card-text class="my-2 py-0 px-2">
-      <v-btn @click="login = !login" variant=text style="width: 100%" v-if="!login">点击登录，发表评论</v-btn>
+      <v-btn @click="$emit('login')" variant=text style="width: 100%" v-if="!login">点击登录，发表评论</v-btn>
       <v-row v-else>
         <v-col cols=9>
           <v-text-field v-model="content" density="compact" single-line hide-details placeholder="爱书之人，维持良好的社区氛围"></v-text-field>

--- a/src/components/EpubReader.vue
+++ b/src/components/EpubReader.vue
@@ -57,7 +57,7 @@
 
     <v-bottom-sheet class="fixed mb-14" max-height="90%" v-model="menu.panels.comments" contained  z-index="234">
       <book-comments :login="is_login" :comments="comments" @close="set_menu('hide')"
-        @add_review="on_add_review"></book-comments>
+        @login="set_menu('more')" @add_review="on_add_review"></book-comments>
     </v-bottom-sheet>
 
     <v-bottom-sheet class="fixed mb-14" max-height="90%" v-model="menu.panels.ai" contained z-index="234">

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,83 @@
+# candle-reader UI Mock 测试
+
+基于 **Playwright** 的端到端 UI 测试。后端 talebook 接口全部通过路由拦截（`page.route('**/api/**')`）mock，
+测试**不依赖真实服务**，结果可复现、可离线运行。
+
+## 运行
+
+```bash
+npm install            # 含 @playwright/test
+npx playwright install chromium   # 首次需安装浏览器
+npm run test:e2e       # 跑全部用例（自动拉起 vite dev server）
+npm run test:e2e:ui    # 带 UI 调试面板
+npx playwright test comments-login   # 只跑某个 spec
+```
+
+## 设计要点
+
+- **测试入口**：`fixtures/reader-harness.html` —— 复刻生产 `index.html`，但把 `server` 指向同源、
+  `book_url` 指向体积较小的 `/demo/book1.epub`，避免跨域与超时，使阅读器能真实渲染。
+- **接口 mock**：`helpers/mock-api.js` —— `setupApiMock(page, overrides)`，默认“游客（未登录）”态，
+  按需用 `overrides` 覆盖单个接口；未显式 mock 的接口返回安全空响应，杜绝真实网络请求。
+- **稳定性**：底部导航与各面板是静态模板，不依赖 epub iframe，断言稳定。
+  评论面板需经 iframe 内交互才会弹出（E2E 中极易 flaky），故通过 Vue 内部实例直接调用
+  `EpubReader.set_menu('comments')` / `show_selected_comments(...)` 打开
+  （`helpers/reader.js` 的 `openPanel` / `openCommentsPanel`），只测 UI 行为本身。
+- **不覆盖 epub 正文渲染**：headless 环境下 epub.js 不渲染正文/不解析目录，这属于第三方
+  渲染器行为而非本项目 UI 逻辑，刻意不纳入断言，以免引入环境相关的 flaky。切换主题/翻页
+  只断言设置状态变化（`rendition` 对象在 mount 后即存在，相关调用不会抛错）。
+
+## 测试用例清单（22 跑 + 2 跳过）
+
+> 带 `@epub` 标签的用例会调用 `rendition.*`（epub.js），headless 下渲染不完整，
+> 暂以 `test.skip` 跳过待讨论。恢复时去掉 `.skip` 即可。
+
+### reader-ui.spec.js — 基础 UI / 导航
+| 用例 | 验证点 |
+| --- | --- |
+| 页面加载后底部导航栏可见 | 目录/设置/用户/AI 四个入口渲染 |
+| 点击「设置」打开设置面板 | 设置面板出现（亮度、翻页） |
+| 点击「AI」打开开发中占位面板 | AI 面板显示“开发中” |
+| 再次点击同一导航项可关闭面板 | `set_menu` 的 toggle 行为 |
+| 设置面板可调整字号 | 点 A+ 后 `settings.font_size` +2 |
+| 设置面板可切换翻页模式 `@epub`（跳过） | 点「上下滑动」后 `settings.flow==='scrolled'` |
+| 点击主题按钮在白天/夜晚间切换 `@epub`（跳过） | `settings.theme_mode` 翻转 |
+
+### auth.spec.js — 登录 / 注册 / 找回密码
+| 用例 | mock | 验证点 |
+| --- | --- | --- |
+| 未登录展示登录表单 | 游客态 | 「用户」面板显示 Guest 登录卡片 |
+| need_login 置 is_login=false | `/api/review/me` → need_login | 内部状态 `is_login===false` |
+| 登录成功展示用户中心 | `sign_in` → ok | 出现“退出登录”，`user` 非空 |
+| 登录失败展示错误 | `sign_in` → 失败 msg | 显示错误文案，不进入用户中心 |
+| 忘记密码重置成功 | `reset` → ok | 显示“重置成功”提示 |
+| 快速注册成功 | `sign_up` → ok | 显示“注册成功”提示 |
+| 启动即已登录 | `user/info` → ok | 「用户」面板直接显示用户中心 |
+
+### user-center.spec.js — 用户中心
+| 用例 | mock | 验证点 |
+| --- | --- | --- |
+| 退出登录成功 | `sign_out` → ok | 确认后 `user` 置空，回到 Guest 登录表单 |
+| 退出登录失败 | `sign_out` → exception | 提示错误且 `user` 仍非空 |
+| 修改昵称成功 | `update` → ok | 保存后对话框关闭 |
+| 修改昵称失败 | `update` → exception | 对话框保留并提示错误 |
+| 未读消息红点 | `review/me` → count=3 | `unread_count===3`，徽标显示 3 |
+
+### comments.spec.js — 章评列表 / 发表（已登录）
+| 用例 | mock | 验证点 |
+| --- | --- | --- |
+| 展示输入框与发表按钮 | `review/me` → ok | 显示输入框与「发表」，无「点击登录」 |
+| 评论列表渲染 | `review/list` → 列表 | 后端评论文案可见 |
+| 发表评论成功追加 | `review/add` → ok | `comments` 长度 +1，新评论可见 |
+
+### comments-login.spec.js — 章评登录入口（回归）
+针对历史 bug：`BookComments` 直接给只读 prop `login` 赋值（`@click="login = !login"`），
+触发 `Set operation on key "login" failed: target is readonly`，点击登录无反应。
+修复为 `$emit('login')` + 父组件 `set_menu('more')`。
+
+| 用例 | 验证点 |
+| --- | --- |
+| 未登录评论面板展示「点击登录」按钮 | 评论列表 + 登录按钮可见 |
+| 点击「点击登录」切换到登录面板，且无 readonly 警告 | 跳转到登录面板**且**控制台无 readonly 警告（双重断言） |
+
+> 该回归用例已验证：还原 bug 代码后用例会失败（登录面板不弹出），修复后通过。

--- a/tests/e2e/auth.spec.js
+++ b/tests/e2e/auth.spec.js
@@ -1,0 +1,89 @@
+// 登录 / 用户中心相关流程，后端全部 mock。
+const { test, expect } = require('@playwright/test')
+const { setupApiMock, SAMPLE_USER } = require('./helpers/mock-api')
+const { gotoReader, readState } = require('./helpers/reader')
+
+test('未登录时「用户」面板展示登录表单', async ({ page }) => {
+  await setupApiMock(page) // 游客态：/api/user/info 返回未登录
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await expect(page.getByText('登录到书评系统')).toBeVisible()
+  await expect(page.getByRole('button', { name: '登录', exact: true })).toBeVisible()
+})
+
+test('/api/review/me 返回 need_login 时 is_login 置为 false', async ({ page }) => {
+  await setupApiMock(page)
+  await gotoReader(page)
+  await expect.poll(() => readState(page, 'is_login')).toBe(false)
+})
+
+test('输入邮箱密码登录成功后展示用户中心', async ({ page }) => {
+  await setupApiMock(page, {
+    'POST /api/user/sign_in': { err: 'ok', data: SAMPLE_USER },
+  })
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByLabel('邮箱').fill(SAMPLE_USER.email)
+  await page.getByLabel('密码').fill('secret123')
+  await page.getByRole('button', { name: '登录', exact: true }).click()
+
+  // 登录成功后 Guest 被 UserCenter 取代
+  await expect(page.getByText('退出登录')).toBeVisible()
+  await expect.poll(() => readState(page, 'user')).not.toBeNull()
+})
+
+test('登录失败时展示错误提示且不进入用户中心', async ({ page }) => {
+  await setupApiMock(page, {
+    'POST /api/user/sign_in': { err: 'auth.failed', msg: '邮箱或密码错误' },
+  })
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByLabel('邮箱').fill('wrong@example.com')
+  await page.getByLabel('密码').fill('bad')
+  await page.getByRole('button', { name: '登录', exact: true }).click()
+
+  await expect(page.getByText('邮箱或密码错误')).toBeVisible()
+  await expect(page.getByText('退出登录')).toBeHidden()
+})
+
+test('忘记密码：重置成功展示提示', async ({ page }) => {
+  await setupApiMock(page, {
+    'POST /api/user/reset': { err: 'ok' },
+  })
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByRole('button', { name: '忘记密码?' }).click()
+  await page.getByLabel('邮箱').fill('reset@example.com')
+  await page.getByRole('button', { name: '重置密码' }).click()
+  await expect(page.getByText('重置成功！请查阅密码通知邮件。')).toBeVisible()
+})
+
+test('快速注册：注册成功展示提示并回到登录', async ({ page }) => {
+  await setupApiMock(page, {
+    'POST /api/user/sign_up': { err: 'ok' },
+  })
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByRole('button', { name: '快速注册' }).click()
+  await page.getByLabel('邮箱').fill('newbie@example.com')
+  await page.getByLabel('昵称').fill('新书友')
+  await page.getByRole('button', { name: '注册', exact: true }).click()
+  await expect(page.getByText('注册成功！请查阅密码通知邮件。')).toBeVisible()
+})
+
+test('启动时已登录则「用户」面板直接展示用户中心', async ({ page }) => {
+  await setupApiMock(page, {
+    'GET /api/user/info': { err: 'ok', data: SAMPLE_USER },
+    'GET /api/review/me': { err: 'ok', data: { count: 3 } },
+  })
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await expect(page.getByText('退出登录')).toBeVisible()
+  await expect(page.getByText('登录到书评系统')).toBeHidden()
+})

--- a/tests/e2e/comments-login.spec.js
+++ b/tests/e2e/comments-login.spec.js
@@ -1,0 +1,43 @@
+// 回归测试：段评/章评面板里的「点击登录，发表评论」。
+// 历史 bug：BookComments 直接对只读 prop `login` 赋值（@click="login = !login"），
+// 触发 Vue 警告 "Set operation on key \"login\" failed: target is readonly"，
+// 点击登录无任何反应。修复后改为 $emit('login')，父组件 set_menu('more') 打开登录面板。
+const { test, expect } = require('@playwright/test')
+const { setupApiMock } = require('./helpers/mock-api')
+const { gotoReader, openPanel } = require('./helpers/reader')
+
+test.describe('章评面板登录入口', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page) // 游客态：评论区显示「点击登录」按钮
+  })
+
+  test('未登录时评论面板展示「点击登录」按钮', async ({ page }) => {
+    await gotoReader(page)
+    await openPanel(page, 'comments')
+    await expect(page.getByText('评论列表')).toBeVisible()
+    await expect(page.getByRole('button', { name: '点击登录，发表评论' })).toBeVisible()
+  })
+
+  test('点击「点击登录」切换到登录面板，且无 readonly 警告', async ({ page }) => {
+    // 捕获控制台警告，用于断言不再出现 readonly 报错
+    const warnings = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' || msg.type() === 'error') {
+        warnings.push(msg.text())
+      }
+    })
+
+    await gotoReader(page)
+    await openPanel(page, 'comments')
+
+    await page.getByRole('button', { name: '点击登录，发表评论' }).click()
+
+    // 修复后：跳转到「用户/more」面板，展示登录表单
+    await expect(page.getByText('登录到书评系统')).toBeVisible()
+    await expect(page.getByRole('button', { name: '登录', exact: true })).toBeVisible()
+
+    // 关键断言：不再有“对只读对象赋值”的 Vue 警告
+    const readonlyWarn = warnings.find((w) => /readonly/i.test(w) && /login/i.test(w))
+    expect(readonlyWarn, `不应出现 readonly 警告，实际捕获:\n${warnings.join('\n')}`).toBeUndefined()
+  })
+})

--- a/tests/e2e/comments.spec.js
+++ b/tests/e2e/comments.spec.js
@@ -1,0 +1,49 @@
+// 章评/段评面板：评论列表展示与发表（已登录态）。
+const { test, expect } = require('@playwright/test')
+const { setupApiMock, SAMPLE_COMMENTS } = require('./helpers/mock-api')
+const { gotoReader, openCommentsPanel, readState } = require('./helpers/reader')
+
+// 已登录态：review/me 返回 ok，使 is_login 保持 true（评论区显示输入框而非登录按钮）
+const LOGGED_IN = { 'GET /api/review/me': { err: 'ok', data: { count: 0 } } }
+
+test('已登录时评论面板展示输入框与发表按钮', async ({ page }) => {
+  await setupApiMock(page, LOGGED_IN)
+  await gotoReader(page)
+  await openCommentsPanel(page)
+
+  await expect(page.getByPlaceholder('爱书之人，维持良好的社区氛围')).toBeVisible()
+  await expect(page.getByRole('button', { name: '发表' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '点击登录，发表评论' })).toBeHidden()
+})
+
+test('评论列表渲染后端返回的评论', async ({ page }) => {
+  await setupApiMock(page, {
+    ...LOGGED_IN,
+    'GET /api/review/list': { err: 'ok', data: { list: SAMPLE_COMMENTS } },
+  })
+  await gotoReader(page)
+  await openCommentsPanel(page)
+
+  await expect(page.getByText('这一段写得真好')).toBeVisible()
+  await expect(page.getByText('深有同感')).toBeVisible()
+})
+
+test('发表评论成功后追加到列表', async ({ page }) => {
+  const newComment = { id: 99, content: '写得很好', nickName: '测试书友', avatar: 'mdi-account', level: 3, createTime: '2026-06-02', geo: '杭州', likeCount: 0 }
+  await setupApiMock(page, {
+    ...LOGGED_IN,
+    'GET /api/review/list': { err: 'ok', data: { list: [] } },
+    'POST /api/review/add': { err: 'ok', data: newComment },
+  })
+  // on_add_review 成功后会 alert('评论成功')，自动接受弹窗
+  page.on('dialog', (d) => d.accept())
+
+  await gotoReader(page)
+  await openCommentsPanel(page)
+
+  await page.getByPlaceholder('爱书之人，维持良好的社区氛围').fill('写得很好')
+  await page.getByRole('button', { name: '发表' }).click()
+
+  await expect.poll(() => readState(page, 'comments').then(c => c.length)).toBe(1)
+  await expect(page.getByText('写得很好')).toBeVisible()
+})

--- a/tests/e2e/fixtures/reader-harness.html
+++ b/tests/e2e/fixtures/reader-harness.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <title>candle-reader e2e harness</title>
+  <!-- 与生产 index.html 一致，epub.js 以全局脚本方式引入 -->
+  <script src="/js/epub-v0.3.88.js"></script>
+  <script type="module">
+    import { Reader } from "/src/main.js"
+    // server 指向本地同源，使所有 /api/** 请求都走同源、便于 Playwright route mock；
+    // book_url 用体积较小的 demo 书，确保阅读器能真实渲染。
+    new Reader('#app', {
+      debug: false,
+      themes_css: "/css/themes.css",
+      server: window.location.origin,
+      book_url: "/demo/book1.epub",
+    })
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/tests/e2e/helpers/mock-api.js
+++ b/tests/e2e/helpers/mock-api.js
@@ -1,0 +1,66 @@
+// 后端接口 mock。candle-reader 通过 $backend(server + url) 请求 talebook 后端，
+// 这里用 Playwright route 拦截所有 /api/** 请求并返回受控 JSON，
+// 使 UI 测试不依赖真实服务、结果可复现。
+
+// 默认的“游客（未登录）”后端状态
+const GUEST_RESPONSES = {
+  'GET /api/review/me': { err: 'user.need_login', msg: '请先登录' },
+  'GET /api/user/info': { err: 'need_login', msg: '未登录' },
+  'GET /api/review/book': { err: 'ok', data: { id: 101 } },
+  'GET /api/review/summary': { err: 'ok', data: { list: [] } },
+  'GET /api/review/list': { err: 'ok', data: { list: [] } },
+}
+
+// 一个示例已登录用户
+const SAMPLE_USER = {
+  id: 1,
+  nickname: '测试书友',
+  email: 'reader@example.com',
+  avatar: 'mdi-account',
+}
+
+// 示例章评列表
+const SAMPLE_COMMENTS = [
+  { id: 11, content: '这一段写得真好', nickName: '路人甲', avatar: 'mdi-account', level: 1, createTime: '2026-06-01', geo: '北京', likeCount: 5 },
+  { id: 12, content: '深有同感', nickName: '路人乙', avatar: 'mdi-account', level: 2, createTime: '2026-06-02', geo: '上海', likeCount: 2 },
+]
+
+/**
+ * 安装后端 mock。
+ * @param {import('@playwright/test').Page} page
+ * @param {object} overrides 形如 { 'GET /api/user/info': {err:'ok', data:{...}} } 的覆盖项
+ * @returns {{ calls: Array<{method:string,url:string}> }} 记录被调用的接口，便于断言
+ */
+async function setupApiMock(page, overrides = {}) {
+  const responses = { ...GUEST_RESPONSES, ...overrides }
+  const calls = []
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const method = request.method()
+    const url = new URL(request.url())
+    const key = `${method} ${url.pathname}`
+    calls.push({ method, url: url.pathname + url.search })
+
+    const body = responses[key]
+    if (body === undefined) {
+      // 未显式 mock 的接口，返回一个安全的空成功响应，避免真实网络请求
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ err: 'ok', data: {} }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: body.__status || 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+  })
+
+  return { calls }
+}
+
+module.exports = { setupApiMock, SAMPLE_USER, SAMPLE_COMMENTS, GUEST_RESPONSES }

--- a/tests/e2e/helpers/reader.js
+++ b/tests/e2e/helpers/reader.js
@@ -1,0 +1,52 @@
+// 阅读器测试通用辅助函数
+
+const HARNESS_URL = '/tests/e2e/fixtures/reader-harness.html'
+
+/**
+ * 打开阅读器测试页，并等待底部导航栏渲染完成。
+ * 底部导航是静态模板，不依赖 epub 加载，因此可作为“页面就绪”的稳定信号。
+ */
+async function gotoReader(page) {
+  await page.goto(HARNESS_URL)
+  await page.getByRole('button', { name: '目录' }).waitFor({ state: 'visible' })
+}
+
+/**
+ * 通过 Vue 内部实例直接调用 EpubReader.set_menu()，可靠地打开指定面板，
+ * 无需依赖 epub iframe 内的文字选择/图标点击（那类交互在 E2E 中极易 flaky）。
+ *
+ * 组件树：#app -> CandleReader(root) -> EpubReader(唯一子组件)
+ */
+async function openPanel(page, name) {
+  await page.evaluate((panel) => {
+    const app = document.querySelector('#app').__vue_app__
+    const epub = app._instance.subTree.component // CandleReader 的根 vnode 即 EpubReader
+    epub.proxy.set_menu(panel)
+  }, name)
+}
+
+/** 读取 EpubReader 上某个响应式数据的当前值，便于断言内部状态。 */
+async function readState(page, key) {
+  return page.evaluate((k) => {
+    const app = document.querySelector('#app').__vue_app__
+    const epub = app._instance.subTree.component
+    return epub.proxy[k]
+  }, key)
+}
+
+/**
+ * 模拟“选中段落 -> 发段评”的入口：调用 show_selected_comments，
+ * 它会写入 comments_location、拉取评论列表并打开评论面板。
+ * 相比裸调 set_menu('comments')，这里能让 comments_location 就绪，
+ * 从而支持后续“发表评论”用例。
+ */
+async function openCommentsPanel(page, toc) {
+  await page.evaluate((t) => {
+    const app = document.querySelector('#app').__vue_app__
+    const epub = app._instance.subTree.component
+    const tocObj = t || { label: '第一章', chapter_id: 7 }
+    epub.proxy.show_selected_comments(tocObj, 3, 'epubcfi(/6/4!/4/2)')
+  }, toc)
+}
+
+module.exports = { HARNESS_URL, gotoReader, openPanel, readState, openCommentsPanel }

--- a/tests/e2e/reader-ui.spec.js
+++ b/tests/e2e/reader-ui.spec.js
@@ -1,0 +1,65 @@
+// 阅读器基础 UI：底部导航与各面板的打开/切换。
+// 这些 UI 是静态模板，不依赖 epub 渲染，因此用例稳定。
+const { test, expect } = require('@playwright/test')
+const { setupApiMock } = require('./helpers/mock-api')
+const { gotoReader, readState, waitForBookReady } = require('./helpers/reader')
+
+test.beforeEach(async ({ page }) => {
+  await setupApiMock(page) // 默认游客态
+})
+
+test('页面加载后底部导航栏可见', async ({ page }) => {
+  await gotoReader(page)
+  await expect(page.getByRole('button', { name: '目录' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '设置' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '用户' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'AI' })).toBeVisible()
+})
+
+test('点击「设置」打开设置面板', async ({ page }) => {
+  await gotoReader(page)
+  await page.getByRole('button', { name: '设置' }).click()
+  await expect(page.getByText('亮度')).toBeVisible()
+  await expect(page.getByText('翻页')).toBeVisible()
+})
+
+test('点击「AI」打开开发中占位面板', async ({ page }) => {
+  await gotoReader(page)
+  await page.getByRole('button', { name: 'AI', exact: true }).click()
+  await expect(page.getByText('开发中')).toBeVisible()
+})
+
+test('再次点击同一导航项可关闭面板', async ({ page }) => {
+  await gotoReader(page)
+  const settingsBtn = page.getByRole('button', { name: '设置' })
+  await settingsBtn.click()
+  await expect(page.getByText('亮度')).toBeVisible()
+  // set_menu 对当前已打开的面板再次点击会切到 'hide'
+  await settingsBtn.click()
+  await expect(page.getByText('亮度')).toBeHidden()
+})
+
+test('设置面板可调整字号', async ({ page }) => {
+  await gotoReader(page)
+  await page.getByRole('button', { name: '设置' }).click()
+  const before = await readState(page, 'settings')
+  await page.getByRole('button', { name: 'A+' }).click()
+  const after = await readState(page, 'settings')
+  expect(after.font_size).toBe(before.font_size + 2)
+})
+
+// 以下用例会调用 rendition.*（epub.js），headless 下渲染不完整，暂跳过待讨论。
+test.skip('设置面板可切换翻页模式 @epub', async ({ page }) => {
+  await gotoReader(page)
+  await page.getByRole('button', { name: '设置' }).click()
+  await page.getByRole('button', { name: '上下滑动' }).click()
+  await expect.poll(() => readState(page, 'settings').then(s => s.flow)).toBe('scrolled')
+})
+
+test.skip('点击主题按钮在白天/夜晚间切换 @epub', async ({ page }) => {
+  await gotoReader(page)
+  const before = await readState(page, 'settings').then(s => s.theme_mode)
+  // 底部导航第二个按钮是主题切换（无 value，文案为 夜晚/白天）
+  await page.getByRole('button', { name: /夜晚|白天/ }).click()
+  await expect.poll(() => readState(page, 'settings').then(s => s.theme_mode)).not.toBe(before)
+})

--- a/tests/e2e/reader-ui.spec.js
+++ b/tests/e2e/reader-ui.spec.js
@@ -2,7 +2,7 @@
 // 这些 UI 是静态模板，不依赖 epub 渲染，因此用例稳定。
 const { test, expect } = require('@playwright/test')
 const { setupApiMock } = require('./helpers/mock-api')
-const { gotoReader, readState, waitForBookReady } = require('./helpers/reader')
+const { gotoReader, readState } = require('./helpers/reader')
 
 test.beforeEach(async ({ page }) => {
   await setupApiMock(page) // 默认游客态

--- a/tests/e2e/reader-ui.spec.js
+++ b/tests/e2e/reader-ui.spec.js
@@ -20,7 +20,7 @@ test('点击「设置」打开设置面板', async ({ page }) => {
   await gotoReader(page)
   await page.getByRole('button', { name: '设置' }).click()
   await expect(page.getByText('亮度')).toBeVisible()
-  await expect(page.getByText('翻页')).toBeVisible()
+  await expect(page.getByText('翻页', { exact: true })).toBeVisible()
 })
 
 test('点击「AI」打开开发中占位面板', async ({ page }) => {

--- a/tests/e2e/user-center.spec.js
+++ b/tests/e2e/user-center.spec.js
@@ -1,0 +1,78 @@
+// 用户中心：登出、改昵称、未读消息红点。均以“已登录”态启动。
+const { test, expect } = require('@playwright/test')
+const { setupApiMock, SAMPLE_USER } = require('./helpers/mock-api')
+const { gotoReader, readState } = require('./helpers/reader')
+
+// 已登录态：user/info 返回用户，review/me 返回 ok
+function loggedIn(extra = {}) {
+  return {
+    'GET /api/user/info': { err: 'ok', data: SAMPLE_USER },
+    'GET /api/review/me': { err: 'ok', data: { count: 0 } },
+    ...extra,
+  }
+}
+
+test('退出登录：确认后回到游客登录表单', async ({ page }) => {
+  await setupApiMock(page, loggedIn({ 'GET /api/user/sign_out': { err: 'ok' } }))
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByText('退出登录').click()
+  // 弹出确认框
+  await expect(page.getByText('是否要退出登录？')).toBeVisible()
+  await page.getByRole('button', { name: '确认' }).click()
+
+  // 登出后 user 置空，UserCenter 被 Guest 取代
+  await expect.poll(() => readState(page, 'user')).toBeNull()
+  await expect(page.getByText('登录到书评系统')).toBeVisible()
+})
+
+test('退出登录：失败时停留并提示错误', async ({ page }) => {
+  await setupApiMock(page, loggedIn({
+    'GET /api/user/sign_out': { err: 'exception', msg: '服务异常' },
+  }))
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByText('退出登录').click()
+  await page.getByRole('button', { name: '确认' }).click()
+
+  await expect(page.getByText('服务异常')).toBeVisible()
+  await expect.poll(() => readState(page, 'user')).not.toBeNull()
+})
+
+test('修改昵称：保存成功后关闭对话框', async ({ page }) => {
+  await setupApiMock(page, loggedIn({
+    'POST /api/user/update': { err: 'ok', data: { ...SAMPLE_USER, nickname: '新昵称' } },
+  }))
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByText('昵称').click()
+  await expect(page.getByText('修改昵称')).toBeVisible()
+  await page.getByLabel('新昵称').fill('新昵称')
+  await page.getByRole('button', { name: '保存' }).click()
+  await expect(page.getByText('修改昵称')).toBeHidden()
+})
+
+test('修改昵称：失败时对话框保留并提示', async ({ page }) => {
+  await setupApiMock(page, loggedIn({
+    'POST /api/user/update': { err: 'exception', msg: '昵称已被占用' },
+  }))
+  await gotoReader(page)
+
+  await page.getByRole('button', { name: '用户' }).click()
+  await page.getByText('昵称').click()
+  await page.getByLabel('新昵称').fill('重复昵称')
+  await page.getByRole('button', { name: '保存' }).click()
+
+  await expect(page.getByText('昵称已被占用')).toBeVisible()
+  await expect(page.getByText('修改昵称')).toBeVisible()
+})
+
+test('有未读消息时「用户」按钮显示红点角标', async ({ page }) => {
+  await setupApiMock(page, loggedIn({ 'GET /api/review/me': { err: 'ok', data: { count: 3 } } }))
+  await gotoReader(page)
+  await expect.poll(() => readState(page, 'unread_count')).toBe(3)
+  await expect(page.locator('.v-badge__badge').filter({ hasText: '3' })).toBeVisible()
+})


### PR DESCRIPTION
## 背景 / 问题
在段落中选中文字点击【发段评】，未登录时面板显示「点击登录，发表评论」，但点击后无反应、登录框不弹出。控制台报 Vue 警告：

> `[Vue warn] Set operation on key "login" failed: target is readonly.`

## 根因
`BookComments.vue` 把只读 prop `login` 当可写状态切换：`@click="login = !login"`。Vue 3 中 props 只读，赋值被阻止，登录入口失效。真正的登录 UI 在父组件 `EpubReader.vue` 的 `more` 面板（`<guest>`）。

## 修复
- `BookComments.vue`：改为 `$emit('login')`，不再改写只读 prop
- `EpubReader.vue`：`<book-comments>` 监听 `@login="set_menu('more')"`，切换到登录面板

## 新增测试 / CI
- 基于 **Playwright** 的 UI mock 测试：后端 `/api/**` 全部路由拦截 mock，不依赖真实 talebook 服务
- 覆盖：底部导航/面板、登录/注册/找回密码、用户中心（登出/改昵称/未读红点）、章评列表与发表，以及**本次 bug 的回归用例**（已验证：还原 bug 代码会失败、修复后通过）
- `.github/workflows/e2e.yml`：PR/push 自动跑 `npm run test:e2e`
- 结果：**22 passed + 2 skipped**

## 已知限制
涉及 epub.js 正文渲染的 2 个用例（`@epub` 标签）在 headless 环境渲染不完整，暂 `test.skip` 待后续讨论（详见 `tests/e2e/README.md`）。文件本身能正常下载、`book`/`rendition` 也建立成功，卡在 epub.js 自身的解析/渲染环节，非应用 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)