### PR TITLE
feat: add synchronized audiobook playback

### DIFF
--- a/src/CandleReader.vue
+++ b/src/CandleReader.vue
@@ -2,6 +2,9 @@
   <EpubReader
           :book_url="book_url" :display_url="display_url"
           :debug="debug" :themes_css="themes_css"
+          :initial_book_id="book_id"
+          :audiobook_edition_id="audiobook_edition_id"
+          :audiobook_manifest_url="audiobook_manifest_url"
           />
 </template>
 
@@ -28,6 +31,18 @@ export default {
     themes_css: {
       type: String,
       default: "theme.css"
+    },
+    book_id: {
+      type: [Number, String],
+      default: null
+    },
+    audiobook_edition_id: {
+      type: [Number, String],
+      default: null
+    },
+    audiobook_manifest_url: {
+      type: String,
+      default: ''
     }
   },
   data: () => ({

--- a/src/audiobook/locator.js
+++ b/src/audiobook/locator.js
@@ -1,0 +1,209 @@
+const ACTIVE_ATTRIBUTE = 'data-candle-audiobook-active'
+const HIGHLIGHT_NAME = 'candle-audiobook'
+const FALLBACK_CLASS = 'candle-audiobook-active'
+
+export function normalizeText(value) {
+  return String(value || '').replace(/\s+/g, '').trim()
+}
+
+export function findSegmentAt(segments, positionMs) {
+  let left = 0
+  let right = segments.length - 1
+  let found = -1
+
+  while (left <= right) {
+    const middle = Math.floor((left + right) / 2)
+    if (Number(segments[middle].start_ms) <= positionMs) {
+      found = middle
+      left = middle + 1
+    } else {
+      right = middle - 1
+    }
+  }
+
+  if (found < 0) return null
+  const segment = segments[found]
+  return positionMs < Number(segment.end_ms) ? segment : null
+}
+
+function cleanHref(value) {
+  const decoded = decodeURIComponent(String(value || '').split(/[?#]/)[0])
+  return decoded.replace(/^\.\//, '').replace(/^\//, '')
+}
+
+function hrefMatches(left, right) {
+  const a = cleanHref(left)
+  const b = cleanHref(right)
+  if (!a || !b) return false
+  return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`) || a.split('/').pop() === b.split('/').pop()
+}
+
+export function contentHref(contents) {
+  return contents?.section?.href || contents?.section?.url || contents?.document?.location?.pathname || ''
+}
+
+export function findContent(rendition, href) {
+  const views = rendition?.views?.() || []
+  let matchedView = null
+  views.forEach?.((view) => {
+    if (!matchedView && hrefMatches(view?.section?.href || view?.section?.url, href)) matchedView = view
+  })
+  if (matchedView?.contents) return matchedView.contents
+
+  const items = rendition?.getContents?.() || []
+  if (!href) return items[0] || null
+  return items.find(item => hrefMatches(contentHref(item), href)) || null
+}
+
+function childrenByTag(parent, tagName) {
+  return Array.from(parent?.children || []).filter(child => child.localName?.toLowerCase() === tagName)
+}
+
+export function resolveDomPath(document, domPath) {
+  const parts = String(domPath || '')
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+  if (!parts.length) return null
+
+  let current = document.documentElement
+  for (const part of parts) {
+    const match = part.match(/^([\w-]+)(?:\[(\d+)\])?$/)
+    if (!match) return null
+    const tagName = match[1].toLowerCase()
+    const index = Math.max(0, Number(match[2] || 1) - 1)
+
+    if (tagName === 'html') {
+      current = document.documentElement
+      continue
+    }
+    if (tagName === 'body') {
+      current = document.body
+      continue
+    }
+    current = childrenByTag(current, tagName)[index]
+    if (!current) return null
+  }
+  return current
+}
+
+function findByText(document, text) {
+  const needle = normalizeText(text)
+  if (!needle) return null
+  const candidates = document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote, div')
+  return Array.from(candidates).find((element) => {
+    const candidate = normalizeText(element.textContent)
+    return candidate === needle || candidate.includes(needle) || needle.includes(candidate)
+  }) || null
+}
+
+export function resolveLocator(contents, segment) {
+  const document = contents?.document
+  const locator = segment?.locator || {}
+  if (!document) return null
+
+  let element = locator.element_id ? document.getElementById(locator.element_id) : null
+  if (!element && locator.dom_path) element = resolveDomPath(document, locator.dom_path)
+  if (!element) element = findByText(document, segment.text)
+  return element ? { document, element, locator } : null
+}
+
+function textNodes(element) {
+  const nodes = []
+  const walker = element.ownerDocument.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let node = walker.nextNode()
+  while (node) {
+    nodes.push(node)
+    node = walker.nextNode()
+  }
+  return nodes
+}
+
+function pointAt(nodes, offset) {
+  let remaining = Math.max(0, offset)
+  for (const node of nodes) {
+    if (remaining <= node.data.length) return { node, offset: remaining }
+    remaining -= node.data.length
+  }
+  const last = nodes[nodes.length - 1]
+  return last ? { node: last, offset: last.data.length } : null
+}
+
+export function createTextRange(element, startChar, endChar) {
+  const nodes = textNodes(element)
+  if (!nodes.length) return null
+  const total = nodes.reduce((sum, node) => sum + node.data.length, 0)
+  const start = Math.min(total, Math.max(0, Number(startChar) || 0))
+  const requestedEnd = Number(endChar)
+  const end = Math.min(total, Number.isFinite(requestedEnd) && requestedEnd > start ? requestedEnd : total)
+  const startPoint = pointAt(nodes, start)
+  const endPoint = pointAt(nodes, end)
+  if (!startPoint || !endPoint) return null
+
+  const range = element.ownerDocument.createRange()
+  range.setStart(startPoint.node, startPoint.offset)
+  range.setEnd(endPoint.node, endPoint.offset)
+  return range
+}
+
+function ensureHighlightStyle(document) {
+  if (document.getElementById('candle-audiobook-highlight-style')) return
+  const style = document.createElement('style')
+  style.id = 'candle-audiobook-highlight-style'
+  style.textContent = `
+    ::highlight(${HIGHLIGHT_NAME}) {
+      background: rgba(245, 166, 35, .34);
+      text-decoration: underline 2px rgba(180, 92, 0, .75);
+      text-underline-offset: .18em;
+    }
+    .${FALLBACK_CLASS} {
+      background: rgba(245, 166, 35, .2) !important;
+      box-shadow: inset 3px 0 rgba(180, 92, 0, .72);
+    }
+  `
+  document.head.appendChild(style)
+}
+
+export function clearHighlights(rendition) {
+  const contents = rendition?.getContents?.() || []
+  contents.forEach((item) => {
+    const document = item.document
+    if (!document) return
+    document.defaultView?.CSS?.highlights?.delete(HIGHLIGHT_NAME)
+    document.querySelectorAll(`[${ACTIVE_ATTRIBUTE}]`).forEach((element) => {
+      element.removeAttribute(ACTIVE_ATTRIBUTE)
+      element.classList.remove(FALLBACK_CLASS)
+    })
+  })
+}
+
+export function applyHighlight(rendition, contents, segment) {
+  clearHighlights(rendition)
+  const resolved = resolveLocator(contents, segment)
+  if (!resolved) return null
+
+  const { document, element, locator } = resolved
+  ensureHighlightStyle(document)
+  element.setAttribute(ACTIVE_ATTRIBUTE, segment.id || '')
+  element.classList.add(FALLBACK_CLASS)
+
+  const range = createTextRange(element, locator.start_char, locator.end_char)
+  const view = document.defaultView
+  if (range && view?.CSS?.highlights && view.Highlight) {
+    view.CSS.highlights.set(HIGHLIGHT_NAME, new view.Highlight(range))
+  }
+  element.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+  return { contents, document, element, range }
+}
+
+export function chapterMatchesHref(chapter, href) {
+  return hrefMatches(chapter?.source_key, href)
+}
+
+export function segmentMatchesElement(segment, element) {
+  if (!segment || !element) return false
+  if (segment.locator?.element_id && segment.locator.element_id === element.id) return true
+  const segmentText = normalizeText(segment.text)
+  const elementText = normalizeText(element.textContent)
+  return Boolean(segmentText && elementText && (elementText.includes(segmentText) || segmentText.includes(elementText)))
+}

--- a/src/components/AudiobookPlayer.vue
+++ b/src/components/AudiobookPlayer.vue
@@ -119,6 +119,9 @@ const followNarration = ref(true)
 const sessionId = ref('')
 const progressVersion = ref(0)
 const rates = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 2]
+const highlightRetryIntervalMs = 50
+const highlightSettleMs = 100
+const highlightRetryAttempts = 40
 
 let syncTimer = null
 let progressTimer = null
@@ -135,6 +138,15 @@ watch(
   () => [props.visible, props.editionId, props.manifestUrl],
   ([visible]) => {
     if (visible) void loadManifest()
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.rendition,
+  (rendition, previousRendition) => {
+    previousRendition?.off?.('rendered', onRenditionRendered)
+    rendition?.on?.('rendered', onRenditionRendered)
   },
   { immediate: true },
 )
@@ -348,16 +360,36 @@ function syncActiveSegment(force = false) {
 async function highlightSegment(segment) {
   const sequence = ++highlightSequence
   const locator = segment.locator || {}
-  let contents = findContent(props.rendition, locator.href || chapter.value?.source_key)
+  const href = locator.href || chapter.value?.source_key
+  let contents = findContent(props.rendition, href)
 
   if (!contents && props.rendition && followNarration.value) {
-    await props.rendition.display(locator.href || chapter.value?.source_key)
-    await new Promise(resolve => window.setTimeout(resolve, 80))
-    contents = findContent(props.rendition, locator.href || chapter.value?.source_key)
+    await props.rendition.display(href)
   }
-  if (sequence !== highlightSequence || !followNarration.value) return
-  if (!contents || !applyHighlight(props.rendition, contents, segment)) {
+
+  for (let attempt = 0; attempt < highlightRetryAttempts; attempt += 1) {
+    if (sequence !== highlightSequence || !followNarration.value) return
+    contents = findContent(props.rendition, href)
+    if (contents && applyHighlight(props.rendition, contents, segment)) {
+      await new Promise(resolve => window.setTimeout(resolve, highlightSettleMs))
+      if (sequence !== highlightSequence || !followNarration.value) return
+
+      const settledContents = findContent(props.rendition, href)
+      const highlighted = settledContents?.document?.querySelector('[data-candle-audiobook-active]')
+      if (highlighted?.getAttribute('data-candle-audiobook-active') === segment.id) return
+    }
+
+    await new Promise(resolve => window.setTimeout(resolve, highlightRetryIntervalMs))
+  }
+
+  if (sequence === highlightSequence && followNarration.value) {
     console.warn('[candle-audiobook] 无法定位时间轴片段', segment.id)
+  }
+}
+
+function onRenditionRendered() {
+  if (activeSegment.value && followNarration.value && playing.value) {
+    void highlightSegment(activeSegment.value)
   }
 }
 
@@ -476,6 +508,7 @@ function formatTime(value) {
 
 onBeforeUnmount(() => {
   stopTimers()
+  props.rendition?.off?.('rendered', onRenditionRendered)
   clearCurrentHighlight()
   if (sessionId.value) void props.request(`/api/audiobook-sessions/${sessionId.value}`, { method: 'POST' })
 })

--- a/src/components/AudiobookPlayer.vue
+++ b/src/components/AudiobookPlayer.vue
@@ -1,0 +1,522 @@
+<template>
+  <section
+    v-if="visible"
+    class="audiobook-player"
+    data-testid="candle-audiobook-player"
+    aria-label="边听边读播放器"
+  >
+    <header class="player-heading">
+      <div>
+        <span class="player-kicker">边听边读</span>
+        <strong>{{ chapter?.title || '正在载入有声书' }}</strong>
+      </div>
+      <button type="button" class="icon-button" aria-label="关闭听书播放器" @click="emit('close')">
+        <v-icon size="20">mdi-close</v-icon>
+      </button>
+    </header>
+
+    <p class="active-dialogue" :class="{ muted: !activeSegment }">
+      {{ activeSegment?.text || (loading ? '正在加载章节时间轴…' : '片段间留白') }}
+    </p>
+
+    <div v-if="error" class="player-error" role="alert">{{ error }}</div>
+
+    <div class="player-controls">
+      <button type="button" class="icon-button" aria-label="上一章" :disabled="chapterIndex <= 0" @click="previousChapter">
+        <v-icon>mdi-skip-previous</v-icon>
+      </button>
+      <button
+        type="button"
+        class="play-button"
+        :aria-label="playing ? '暂停听书' : '播放听书'"
+        :disabled="loading || !chapter"
+        @click="togglePlayback"
+      >
+        <v-icon>{{ playing ? 'mdi-pause' : 'mdi-play' }}</v-icon>
+      </button>
+      <button type="button" class="icon-button" aria-label="下一章" :disabled="chapterIndex >= chapters.length - 1" @click="nextChapter">
+        <v-icon>mdi-skip-next</v-icon>
+      </button>
+
+      <span class="time">{{ formatTime(positionMs) }}</span>
+      <input
+        class="timeline-slider"
+        type="range"
+        min="0"
+        :max="Math.max(durationMs, 1)"
+        step="100"
+        :value="positionMs"
+        aria-label="听书进度"
+        @input="seek(Number($event.target.value))"
+      >
+      <span class="time">{{ formatTime(durationMs) }}</span>
+
+      <label class="rate-control">
+        <span class="sr-only">播放速度</span>
+        <select v-model.number="rate" aria-label="播放速度" @change="updateRate">
+          <option v-for="value in rates" :key="value" :value="value">x{{ value }}</option>
+        </select>
+      </label>
+    </div>
+
+    <button
+      v-if="!followNarration"
+      type="button"
+      class="return-button"
+      data-testid="return-to-narration"
+      @click="returnToNarration"
+    >
+      <v-icon size="18">mdi-target</v-icon>
+      回到朗读位置
+    </button>
+
+    <audio
+      ref="audioElement"
+      preload="metadata"
+      @loadedmetadata="onLoadedMetadata"
+      @play="onPlay"
+      @pause="onPause"
+      @ended="onEnded"
+      @error="onAudioError"
+    ></audio>
+  </section>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import {
+  applyHighlight,
+  chapterMatchesHref,
+  clearHighlights,
+  contentHref,
+  findContent,
+  findSegmentAt,
+  normalizeText,
+  segmentMatchesElement,
+} from '@/audiobook/locator'
+
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  editionId: { type: [Number, String], default: null },
+  manifestUrl: { type: String, default: '' },
+  rendition: { type: Object, default: null },
+  request: { type: Function, required: true },
+})
+
+const emit = defineEmits(['close', 'segment-change'])
+const audioElement = ref(null)
+const manifest = ref(null)
+const chapter = ref(null)
+const timeline = ref([])
+const activeSegment = ref(null)
+const playing = ref(false)
+const loading = ref(false)
+const error = ref('')
+const positionMs = ref(0)
+const durationMs = ref(0)
+const rate = ref(1)
+const followNarration = ref(true)
+const sessionId = ref('')
+const progressVersion = ref(0)
+const rates = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 2]
+
+let syncTimer = null
+let progressTimer = null
+let manifestPromise = null
+let activeSegmentId = ''
+let highlightSequence = 0
+let lastProgressClock = 0
+
+const chapters = computed(() => manifest.value?.chapters || [])
+const chapterIndex = computed(() => chapters.value.findIndex(item => item.id === chapter.value?.id))
+const storageKey = computed(() => `candle:audiobook:${props.editionId || 'manifest'}`)
+
+watch(
+  () => [props.visible, props.editionId, props.manifestUrl],
+  ([visible]) => {
+    if (visible) void loadManifest()
+  },
+  { immediate: true },
+)
+
+function manifestEndpoint() {
+  return props.manifestUrl || (props.editionId ? `/api/audiobooks/${props.editionId}/manifest` : '')
+}
+
+function loadManifest() {
+  if (manifest.value || !manifestEndpoint()) return Promise.resolve()
+  if (manifestPromise) return manifestPromise
+  manifestPromise = loadManifestOnce().finally(() => {
+    manifestPromise = null
+  })
+  return manifestPromise
+}
+
+async function loadManifestOnce() {
+  loading.value = true
+  error.value = ''
+  try {
+    const response = await props.request(manifestEndpoint())
+    if (response.err !== 'ok' || !response.manifest?.chapters?.length) {
+      throw new Error(response.msg || '当前书籍没有可播放章节')
+    }
+    manifest.value = response.manifest
+    progressVersion.value = response.progress?.version || 0
+
+    const saved = readSavedState()
+    const target = chapters.value.find(item => item.id === response.progress?.chapter_id)
+      || chapters.value.find(item => item.number === saved.chapterNumber)
+      || chapters.value[0]
+    const startMs = response.progress?.position_ms ?? saved.positionMs ?? 0
+    rate.value = saved.rate || 1
+    await loadChapter(target, { startMs, autoplay: false, navigate: false })
+  } catch (cause) {
+    error.value = cause?.message || '有声书加载失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadTimeline(target) {
+  const endpoint = target.timeline_url || `/api/audiobooks/${manifest.value.id}/chapters/${target.number}/timeline`
+  const response = await props.request(endpoint)
+  timeline.value = response.err === 'ok' ? (response.timeline?.segments || []) : []
+}
+
+async function loadChapter(target, { startMs = 0, autoplay = false, navigate = true } = {}) {
+  if (!target) return
+  loading.value = true
+  error.value = ''
+  clearCurrentHighlight()
+  try {
+    chapter.value = target
+    positionMs.value = Math.max(0, Number(startMs) || 0)
+    durationMs.value = Number(target.duration_ms) || 0
+    await loadTimeline(target)
+
+    if (navigate && followNarration.value) await navigateToChapter(target)
+    await nextTick()
+    const audio = audioElement.value
+    if (!audio) return
+    const resolvedAudioUrl = new URL(target.audio_url, window.location.href).href
+    if (audio.src !== resolvedAudioUrl) {
+      audio.src = target.audio_url
+      audio.load()
+    }
+    await waitForMetadata(audio)
+    audio.playbackRate = rate.value
+    audio.currentTime = Math.min(positionMs.value / 1000, audio.duration || Infinity)
+    saveState()
+    syncActiveSegment(true)
+    if (autoplay) await startPlayback()
+  } catch (cause) {
+    error.value = cause?.message || '章节音频加载失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function navigateToChapter(target) {
+  if (!props.rendition || !target?.source_key) return
+  await props.rendition.display(target.source_key)
+}
+
+async function ensureSession() {
+  if (sessionId.value || !manifest.value) return
+  const response = await props.request(`/api/audiobooks/${manifest.value.id}/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source: 'candle', device_id: 'candle-reader' }),
+  })
+  if (response.err === 'ok') sessionId.value = response.session_id || ''
+}
+
+async function startPlayback() {
+  const audio = audioElement.value
+  if (!audio) return
+  await ensureSession()
+  audio.playbackRate = rate.value
+  try {
+    await audio.play()
+  } catch (cause) {
+    error.value = cause?.name === 'NotAllowedError' ? '请再次点击播放' : '无法播放章节音频'
+  }
+}
+
+async function togglePlayback() {
+  if (!manifest.value) await loadManifest()
+  const audio = audioElement.value
+  if (!audio || !chapter.value) return
+  if (audio.paused) await startPlayback()
+  else audio.pause()
+}
+
+function onLoadedMetadata() {
+  const audio = audioElement.value
+  if (!audio) return
+  durationMs.value = Number.isFinite(audio.duration) ? Math.round(audio.duration * 1000) : durationMs.value
+}
+
+function waitForMetadata(audio) {
+  if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const onReady = () => {
+      cleanup()
+      resolve()
+    }
+    const onError = () => {
+      cleanup()
+      reject(new Error('章节音频元数据加载失败'))
+    }
+    const cleanup = () => {
+      audio.removeEventListener('loadedmetadata', onReady)
+      audio.removeEventListener('error', onError)
+    }
+    audio.addEventListener('loadedmetadata', onReady)
+    audio.addEventListener('error', onError)
+  })
+}
+
+function onPlay() {
+  playing.value = true
+  lastProgressClock = Date.now()
+  syncActiveSegment(true)
+  startTimers()
+  updateMediaSession()
+}
+
+function onPause() {
+  playing.value = false
+  stopTimers()
+  sampleAudioPosition()
+  void reportProgress(true)
+  saveState()
+}
+
+async function onEnded() {
+  playing.value = false
+  stopTimers()
+  await reportProgress(true, chapterIndex.value === chapters.value.length - 1)
+  if (chapterIndex.value < chapters.value.length - 1) {
+    await loadChapter(chapters.value[chapterIndex.value + 1], { autoplay: true })
+  }
+}
+
+function onAudioError() {
+  if (!audioElement.value?.src) return
+  error.value = '章节音频加载失败'
+  playing.value = false
+  stopTimers()
+}
+
+function startTimers() {
+  stopTimers()
+  syncTimer = window.setInterval(sampleAudioPosition, 150)
+  progressTimer = window.setInterval(() => void reportProgress(), 10000)
+}
+
+function stopTimers() {
+  if (syncTimer) window.clearInterval(syncTimer)
+  if (progressTimer) window.clearInterval(progressTimer)
+  syncTimer = null
+  progressTimer = null
+}
+
+function sampleAudioPosition() {
+  const audio = audioElement.value
+  if (!audio) return
+  positionMs.value = Math.round(audio.currentTime * 1000)
+  syncActiveSegment()
+  saveState()
+}
+
+function syncActiveSegment(force = false) {
+  const segment = findSegmentAt(timeline.value, positionMs.value)
+  const nextId = segment?.id || ''
+  if (!force && nextId === activeSegmentId) return
+  activeSegmentId = nextId
+  activeSegment.value = segment
+  emit('segment-change', segment)
+
+  if (!segment || !followNarration.value || !playing.value) {
+    clearCurrentHighlight()
+    return
+  }
+  void highlightSegment(segment)
+}
+
+async function highlightSegment(segment) {
+  const sequence = ++highlightSequence
+  const locator = segment.locator || {}
+  let contents = findContent(props.rendition, locator.href || chapter.value?.source_key)
+
+  if (!contents && props.rendition && followNarration.value) {
+    await props.rendition.display(locator.href || chapter.value?.source_key)
+    await new Promise(resolve => window.setTimeout(resolve, 80))
+    contents = findContent(props.rendition, locator.href || chapter.value?.source_key)
+  }
+  if (sequence !== highlightSequence || !followNarration.value) return
+  if (!contents || !applyHighlight(props.rendition, contents, segment)) {
+    console.warn('[candle-audiobook] 无法定位时间轴片段', segment.id)
+  }
+}
+
+function clearCurrentHighlight() {
+  highlightSequence += 1
+  clearHighlights(props.rendition)
+}
+
+function suspendFollow() {
+  if (!chapter.value || !activeSegment.value) return
+  followNarration.value = false
+  clearCurrentHighlight()
+}
+
+async function returnToNarration() {
+  followNarration.value = true
+  if (activeSegment.value) await highlightSegment(activeSegment.value)
+}
+
+function seek(value) {
+  const audio = audioElement.value
+  positionMs.value = Math.max(0, Math.min(durationMs.value, value))
+  if (audio) audio.currentTime = positionMs.value / 1000
+  syncActiveSegment(true)
+  saveState()
+}
+
+function updateRate() {
+  if (audioElement.value) audioElement.value.playbackRate = rate.value
+  saveState()
+}
+
+async function previousChapter() {
+  if (chapterIndex.value > 0) await loadChapter(chapters.value[chapterIndex.value - 1], { autoplay: playing.value })
+}
+
+async function nextChapter() {
+  if (chapterIndex.value < chapters.value.length - 1) await loadChapter(chapters.value[chapterIndex.value + 1], { autoplay: playing.value })
+}
+
+async function playFromSelection(selection) {
+  if (!manifest.value) await loadManifest()
+  if (!manifest.value || !selection) return false
+  followNarration.value = true
+
+  const selectionHref = selection.toc?.href || selection.toc?.id || contentHref(selection.contents)
+  const targetChapter = chapters.value.find(item => chapterMatchesHref(item, selectionHref)) || chapter.value || chapters.value[0]
+  if (targetChapter?.id !== chapter.value?.id) await loadChapter(targetChapter, { navigate: false })
+
+  const cfi = selection.cfi?.toString?.() || selection.cfi
+  const range = cfi && props.rendition?.getRange?.(cfi)
+  const node = range?.startContainer?.nodeType === Node.TEXT_NODE ? range.startContainer.parentElement : range?.startContainer
+  const element = node?.closest?.('p, h1, h2, h3, h4, h5, h6, li, blockquote') || null
+  const elementText = normalizeText(element?.textContent)
+  const matched = (elementText && timeline.value.find(segment => normalizeText(segment.text) === elementText))
+    || (element && timeline.value.find(segment => segmentMatchesElement(segment, element)))
+    || timeline.value.find(segment => Number(segment.index) === Number(selection.segment_id))
+  if (!matched) return false
+
+  await loadChapter(targetChapter, { startMs: matched.start_ms, autoplay: true, navigate: true })
+  return true
+}
+
+async function reportProgress(force = false, completed = false) {
+  if (!sessionId.value || !chapter.value) return
+  const now = Date.now()
+  const delta = playing.value && lastProgressClock ? Math.min(60000, Math.max(0, now - lastProgressClock)) : 0
+  if (!force && delta < 9000) return
+  lastProgressClock = now
+  const response = await props.request(`/api/audiobook-sessions/${sessionId.value}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chapter_id: chapter.value.id,
+      position_ms: positionMs.value,
+      segment_id: activeSegment.value?.id || '',
+      listened_delta_ms: delta,
+      completed,
+      version: progressVersion.value,
+    }),
+  })
+  if (response.err === 'ok') progressVersion.value = response.version || progressVersion.value
+  else if (response.err === 'progress.conflict') progressVersion.value = response.version || progressVersion.value
+}
+
+function readSavedState() {
+  try {
+    return JSON.parse(localStorage.getItem(storageKey.value) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function saveState() {
+  if (!chapter.value) return
+  localStorage.setItem(storageKey.value, JSON.stringify({
+    chapterNumber: chapter.value.number,
+    positionMs: positionMs.value,
+    rate: rate.value,
+  }))
+}
+
+function updateMediaSession() {
+  if (!('mediaSession' in navigator) || !chapter.value) return
+  navigator.mediaSession.metadata = new MediaMetadata({ title: chapter.value.title, album: '边听边读' })
+  navigator.mediaSession.setActionHandler('play', startPlayback)
+  navigator.mediaSession.setActionHandler('pause', () => audioElement.value?.pause())
+  navigator.mediaSession.setActionHandler('previoustrack', previousChapter)
+  navigator.mediaSession.setActionHandler('nexttrack', nextChapter)
+}
+
+function formatTime(value) {
+  const seconds = Math.max(0, Math.floor((value || 0) / 1000))
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+}
+
+onBeforeUnmount(() => {
+  stopTimers()
+  clearCurrentHighlight()
+  if (sessionId.value) void props.request(`/api/audiobook-sessions/${sessionId.value}`, { method: 'POST' })
+})
+
+defineExpose({ loadManifest, playFromSelection, returnToNarration, suspendFollow })
+</script>
+
+<style scoped>
+.audiobook-player {
+  position: fixed;
+  right: 12px;
+  bottom: calc(64px + env(safe-area-inset-bottom));
+  left: 12px;
+  z-index: 2500;
+  padding: 12px 14px;
+  color: #f9f6ef;
+  background: linear-gradient(135deg, rgba(24, 33, 45, .97), rgba(62, 46, 31, .97));
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 18px;
+  box-shadow: 0 14px 45px rgba(0, 0, 0, .34);
+  backdrop-filter: blur(18px);
+}
+.player-heading, .player-controls { display: flex; align-items: center; gap: 9px; }
+.player-heading { justify-content: space-between; }
+.player-heading > div { min-width: 0; display: grid; }
+.player-heading strong { overflow: hidden; font-size: 14px; text-overflow: ellipsis; white-space: nowrap; }
+.player-kicker { color: #f3bd62; font-size: 10px; font-weight: 800; letter-spacing: .16em; }
+.active-dialogue { min-height: 22px; margin: 8px 0; overflow: hidden; color: #fff; font-family: Georgia, 'Noto Serif SC', serif; font-size: 13px; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
+.active-dialogue.muted { color: rgba(255, 255, 255, .55); }
+.icon-button, .play-button, .return-button { border: 0; color: inherit; cursor: pointer; }
+.icon-button { display: grid; flex: 0 0 34px; width: 34px; height: 34px; place-items: center; background: transparent; border-radius: 50%; }
+.icon-button:hover { background: rgba(255, 255, 255, .1); }
+.icon-button:disabled { opacity: .28; cursor: default; }
+.play-button { display: grid; flex: 0 0 40px; width: 40px; height: 40px; place-items: center; color: #2c2116; background: #f3bd62; border-radius: 50%; }
+.timeline-slider { min-width: 54px; flex: 1; accent-color: #f3bd62; }
+.time { color: rgba(255, 255, 255, .7); font-size: 10px; font-variant-numeric: tabular-nums; }
+.rate-control select { padding: 5px 4px; color: inherit; background: rgba(255, 255, 255, .08); border: 1px solid rgba(255, 255, 255, .16); border-radius: 7px; }
+.return-button { display: flex; margin: 9px auto 0; padding: 6px 10px; align-items: center; gap: 5px; color: #2c2116; background: #f3bd62; border-radius: 99px; font-size: 12px; font-weight: 700; }
+.player-error { margin: 6px 0; color: #ffb4ab; font-size: 12px; text-align: center; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+@media (min-width: 700px) {
+  .audiobook-player { right: 24px; bottom: 24px; left: auto; width: min(620px, calc(100vw - 48px)); }
+}
+</style>

--- a/src/components/AudiobookPlayer.vue
+++ b/src/components/AudiobookPlayer.vue
@@ -122,7 +122,6 @@ const rates = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 2]
 const highlightRetryIntervalMs = 50
 const highlightSettleMs = 100
 const highlightRetryAttempts = 40
-const highlightDebugPrefix = '[DEBUG-audiobook-highlight]'
 
 let syncTimer = null
 let progressTimer = null
@@ -363,51 +362,29 @@ async function highlightSegment(segment) {
   const locator = segment.locator || {}
   const href = locator.href || chapter.value?.source_key
   let contents = findContent(props.rendition, href)
-  debugHighlight('start', segment, href, contents)
 
   if (!contents && props.rendition && followNarration.value) {
     await props.rendition.display(href)
-    debugHighlight('displayed', segment, href, findContent(props.rendition, href))
   }
 
   for (let attempt = 0; attempt < highlightRetryAttempts; attempt += 1) {
     if (sequence !== highlightSequence || !followNarration.value) return
     contents = findContent(props.rendition, href)
     if (contents && applyHighlight(props.rendition, contents, segment)) {
-      debugHighlight('applied', segment, href, contents)
       await new Promise(resolve => window.setTimeout(resolve, highlightSettleMs))
       if (sequence !== highlightSequence || !followNarration.value) return
 
       const settledContents = findContent(props.rendition, href)
       const highlighted = settledContents?.document?.querySelector('[data-candle-audiobook-active]')
-      if (highlighted?.getAttribute('data-candle-audiobook-active') === segment.id) {
-        debugHighlight('settled', segment, href, settledContents)
-        return
-      }
-      debugHighlight('replaced', segment, href, settledContents)
+      if (highlighted?.getAttribute('data-candle-audiobook-active') === segment.id) return
     }
 
-    if (attempt === 0 || attempt === highlightRetryAttempts - 1) debugHighlight(`attempt-${attempt + 1}`, segment, href, contents)
     await new Promise(resolve => window.setTimeout(resolve, highlightRetryIntervalMs))
   }
 
   if (sequence === highlightSequence && followNarration.value) {
     console.warn('[candle-audiobook] 无法定位时间轴片段', segment.id)
   }
-}
-
-function debugHighlight(stage, segment, href, contents) {
-  const views = props.rendition?.views?.() || []
-  const viewHrefs = []
-  views.forEach?.(view => viewHrefs.push(view?.section?.href || view?.section?.url || ''))
-  console.info(highlightDebugPrefix, JSON.stringify({
-    stage,
-    segment: segment.id,
-    href,
-    matchedHref: contentHref(contents),
-    hasDocument: Boolean(contents?.document),
-    viewHrefs,
-  }))
 }
 
 function onRenditionRendered() {

--- a/src/components/AudiobookPlayer.vue
+++ b/src/components/AudiobookPlayer.vue
@@ -122,6 +122,7 @@ const rates = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 2]
 const highlightRetryIntervalMs = 50
 const highlightSettleMs = 100
 const highlightRetryAttempts = 40
+const highlightDebugPrefix = '[DEBUG-audiobook-highlight]'
 
 let syncTimer = null
 let progressTimer = null
@@ -362,29 +363,51 @@ async function highlightSegment(segment) {
   const locator = segment.locator || {}
   const href = locator.href || chapter.value?.source_key
   let contents = findContent(props.rendition, href)
+  debugHighlight('start', segment, href, contents)
 
   if (!contents && props.rendition && followNarration.value) {
     await props.rendition.display(href)
+    debugHighlight('displayed', segment, href, findContent(props.rendition, href))
   }
 
   for (let attempt = 0; attempt < highlightRetryAttempts; attempt += 1) {
     if (sequence !== highlightSequence || !followNarration.value) return
     contents = findContent(props.rendition, href)
     if (contents && applyHighlight(props.rendition, contents, segment)) {
+      debugHighlight('applied', segment, href, contents)
       await new Promise(resolve => window.setTimeout(resolve, highlightSettleMs))
       if (sequence !== highlightSequence || !followNarration.value) return
 
       const settledContents = findContent(props.rendition, href)
       const highlighted = settledContents?.document?.querySelector('[data-candle-audiobook-active]')
-      if (highlighted?.getAttribute('data-candle-audiobook-active') === segment.id) return
+      if (highlighted?.getAttribute('data-candle-audiobook-active') === segment.id) {
+        debugHighlight('settled', segment, href, settledContents)
+        return
+      }
+      debugHighlight('replaced', segment, href, settledContents)
     }
 
+    if (attempt === 0 || attempt === highlightRetryAttempts - 1) debugHighlight(`attempt-${attempt + 1}`, segment, href, contents)
     await new Promise(resolve => window.setTimeout(resolve, highlightRetryIntervalMs))
   }
 
   if (sequence === highlightSequence && followNarration.value) {
     console.warn('[candle-audiobook] 无法定位时间轴片段', segment.id)
   }
+}
+
+function debugHighlight(stage, segment, href, contents) {
+  const views = props.rendition?.views?.() || []
+  const viewHrefs = []
+  views.forEach?.(view => viewHrefs.push(view?.section?.href || view?.section?.url || ''))
+  console.info(highlightDebugPrefix, JSON.stringify({
+    stage,
+    segment: segment.id,
+    href,
+    matchedHref: contentHref(contents),
+    hasDocument: Boolean(contents?.document),
+    viewHrefs,
+  }))
 }
 
 function onRenditionRendered() {

--- a/src/components/EpubReader.vue
+++ b/src/components/EpubReader.vue
@@ -294,8 +294,15 @@ export default {
     },
   },
   methods: {
-    audiobook_request: function (url, options) {
-      return this.$backend(url, options);
+    audiobook_request: async function (url, options = {}) {
+      const response = await fetch(url, {
+        mode: 'cors',
+        credentials: 'include',
+        ...options,
+      });
+      const payload = await response.json();
+      if (!response.ok && !payload?.err) throw new Error(`有声书接口请求失败（${response.status}）`);
+      return payload;
     },
     open_audiobook: function () {
       this.set_menu('hide');

--- a/src/components/EpubReader.vue
+++ b/src/components/EpubReader.vue
@@ -26,6 +26,11 @@
         <span>{{ switch_theme_text }}</span>
       </v-btn>
 
+      <v-btn v-if="has_audiobook" @click="open_audiobook">
+        <v-icon>mdi-headphones</v-icon>
+        <span>听书</span>
+      </v-btn>
+
       <v-btn value="settings" @click="set_menu('settings')">
         <v-icon>mdi-cog</v-icon>
         <span>设置</span>
@@ -45,6 +50,17 @@
       </v-btn>
 
     </v-bottom-navigation>
+
+    <audiobook-player
+      v-if="has_audiobook"
+      ref="audiobookPlayer"
+      :visible="audiobook_open"
+      :edition-id="audiobook_edition_id"
+      :manifest-url="audiobook_manifest_url"
+      :rendition="rendition"
+      :request="audiobook_request"
+      @close="audiobook_open = false"
+    ></audiobook-player>
 
     <v-bottom-sheet class="fixed mb-14" max-height="90%" v-model="menu.panels.settings" contained persistent z-index="234">
       <settings :settings="settings" @update="update_settings" @open-themes="open_theme_dialog"></settings>
@@ -84,7 +100,7 @@
       <v-toolbar density="compact" border dense floating elevation="10" rounded>
         <v-btn @click="on_click_toolbar_comments">发段评</v-btn>
         <v-divider vertical></v-divider>
-        <v-btn>从这里听</v-btn>
+        <v-btn @click="on_click_toolbar_listen">从这里听</v-btn>
         <v-divider vertical></v-divider>
         <v-btn>复制</v-btn>
         <v-divider vertical></v-divider>
@@ -171,6 +187,7 @@ import Guest from './Guest.vue'
 import UserCenter from './UserCenter.vue'
 import BookComments from './BookComments.vue'
 import BookReview from './BookReview.vue'
+import AudiobookPlayer from './AudiobookPlayer.vue'
 import { THEMES, getTheme } from '@/themes'
 
 export default {
@@ -181,10 +198,22 @@ export default {
     Guest,
     UserCenter,
     BookComments,
-    BookReview
+    BookReview,
+    AudiobookPlayer
   },
-  props: ['book_url', 'display_url', 'debug', 'themes_css'],
+  props: {
+    book_url: { type: String, required: true },
+    display_url: { type: String, default: '' },
+    debug: { type: Boolean, default: false },
+    themes_css: { type: String, default: 'theme.css' },
+    initial_book_id: { type: [Number, String], default: null },
+    audiobook_edition_id: { type: [Number, String], default: null },
+    audiobook_manifest_url: { type: String, default: '' },
+  },
   computed: {
+    has_audiobook: function () {
+      return Boolean(this.audiobook_edition_id || this.audiobook_manifest_url);
+    },
     switch_theme_icon: function () {
       // 当前是白天主题则显示「切换到夜晚」的图标，反之亦然
       const isDayTheme = getTheme(this.settings.theme).mode === 'day';
@@ -265,6 +294,23 @@ export default {
     },
   },
   methods: {
+    audiobook_request: function (url, options) {
+      return this.$backend(url, options);
+    },
+    open_audiobook: function () {
+      this.set_menu('hide');
+      this.audiobook_open = true;
+      this.$nextTick(() => this.$refs.audiobookPlayer?.loadManifest());
+    },
+    suspend_audiobook_follow: function () {
+      this.$refs.audiobookPlayer?.suspendFollow();
+    },
+    on_click_toolbar_listen: function () {
+      const selection = this.selected_location;
+      this.hide_toolbar();
+      this.audiobook_open = true;
+      this.$nextTick(() => this.$refs.audiobookPlayer?.playFromSelection(selection));
+    },
     switch_theme: function () {
       // 在「最近用过的白天主题」与「最近用过的夜晚主题」之间切换
       const isDayTheme = getTheme(this.settings.theme).mode === 'day';
@@ -434,6 +480,7 @@ export default {
     on_click_toc: function (item) {
       console.log(item);
       this.set_menu("hide");
+      this.suspend_audiobook_follow();
       this.rendition.display(item.id);
     },
     on_mousedown: function (mouse_event) {
@@ -487,11 +534,13 @@ export default {
       if ( x < width / N || (is_mobile && y < height / N)) {
         // 点击左侧，往前翻页
         if (!is_keyboard_only) {
+          this.suspend_audiobook_follow();
           this.rendition.prev();
         }
       } else if (x > width * (N-1) / N || (is_mobile && y > height * (N-1) / N)) {
         // 点击右侧，往后翻页
         if (!is_keyboard_only) {
+          this.suspend_audiobook_follow();
           this.rendition.next().then();
         }
       } else {
@@ -698,10 +747,12 @@ export default {
       const c = e.keyCode || e.which;
       // Left & Up
       if (c == 37 || c == 38) {
+        this.suspend_audiobook_follow();
         this.rendition.prev();
       }
       // Right & Down
       if (c == 39 || c == 40) {
+        this.suspend_audiobook_follow();
         this.rendition.next();
       }
     },
@@ -727,6 +778,7 @@ export default {
       if (Math.abs(this.wheel_acc) < 30) return;
 
       e.preventDefault();
+      this.suspend_audiobook_follow();
       this.rendition[this.wheel_acc > 0 ? 'next' : 'prev']();
       this.wheel_acc = 0;
     },
@@ -1153,7 +1205,8 @@ export default {
 
         this.book.ready.then(() => {
           const savedPosition = localStorage.getItem(positionKey);
-          return this.rendition.display(savedPosition || this.display_url);
+          const target = savedPosition || this.display_url;
+          return target ? this.rendition.display(target) : this.rendition.display();
         })
         .then(() => {
           clearTimeout(this.loadingTimeout);
@@ -1181,6 +1234,7 @@ export default {
     },
   },
   mounted: function () {
+    if (this.initial_book_id) this.book_id = Number(this.initial_book_id);
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.type = 'text/css';
@@ -1291,7 +1345,8 @@ export default {
 
     this.book.ready.then(() => {
       const savedPosition = localStorage.getItem(positionKey);
-      return this.rendition.display(savedPosition || this.display_url);
+      const target = savedPosition || this.display_url;
+      return target ? this.rendition.display(target) : this.rendition.display();
     })
     .then(() => {
       clearTimeout(this.loadingTimeout);
@@ -1377,6 +1432,7 @@ export default {
     check_if_selected_content: false,
     showTimeoutDialog: false,
     show_theme_dialog: false,
+    audiobook_open: false,
   })
 }
 </script>

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -106,11 +106,11 @@ async function activeHighlight(page) {
   })
 }
 
+async function expectActiveHighlight(page, expected) {
+  await expect.poll(() => activeHighlight(page), { timeout: 15000 }).toMatchObject(expected)
+}
+
 test.beforeEach(async ({ page }) => {
-  page.on('console', (message) => {
-    if (message.text().includes('[DEBUG-audiobook-highlight]')) console.log(message.text())
-  })
-  page.on('pageerror', (error) => console.log('[DEBUG-audiobook-pageerror]', error.stack || error.message))
   await setupAudiobook(page)
 })
 
@@ -123,7 +123,7 @@ test('播放时间轴会自动翻到对应正文并按句段高亮', async ({ pa
   await page.getByRole('button', { name: '播放听书' }).click()
 
   await expect(player).toContainText('好痛！')
-  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1', text: '好痛！' })
+  await expectActiveHighlight(page, { id: 'seg-1', text: '好痛！' })
 })
 
 test('章节视图延迟注册时仍会重试高亮', async ({ page }) => {
@@ -142,14 +142,14 @@ test('章节视图延迟注册时仍会重试高亮', async ({ page }) => {
   await page.getByRole('button', { name: '播放听书' }).click()
 
   await expect(page.getByTestId('candle-audiobook-player')).toContainText('好痛！')
-  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1', text: '好痛！' })
+  await expectActiveHighlight(page, { id: 'seg-1', text: '好痛！' })
 })
 
 test('手动翻页暂停自动跟随，并可返回当前朗读句段', async ({ page }) => {
   await gotoAudiobookReader(page)
   await page.getByRole('button', { name: '听书', exact: true }).click()
   await page.getByRole('button', { name: '播放听书' }).click()
-  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1' })
+  await expectActiveHighlight(page, { id: 'seg-1' })
 
   await page.keyboard.press('ArrowRight')
   const returnButton = page.getByTestId('return-to-narration')
@@ -158,7 +158,7 @@ test('手动翻页暂停自动跟随，并可返回当前朗读句段', async ({
 
   await returnButton.click()
   await expect(returnButton).toBeHidden()
-  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1' })
+  await expectActiveHighlight(page, { id: 'seg-1' })
 })
 
 test('选中正文后可从对应时间轴片段开始听', async ({ page }) => {
@@ -188,5 +188,5 @@ test('选中正文后可从对应时间轴片段开始听', async ({ page }) => 
   const player = page.getByTestId('candle-audiobook-player')
   await expect(player).toBeVisible()
   await expect(player).toContainText('头好痛！', { timeout: 5000 })
-  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-2', text: '头好痛！' })
+  await expectActiveHighlight(page, { id: 'seg-2', text: '头好痛！' })
 })

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -107,6 +107,10 @@ async function activeHighlight(page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  page.on('console', (message) => {
+    if (message.text().includes('[DEBUG-audiobook-highlight]')) console.log(message.text())
+  })
+  page.on('pageerror', (error) => console.log('[DEBUG-audiobook-pageerror]', error.stack || error.message))
   await setupAudiobook(page)
 })
 

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -1,0 +1,169 @@
+const { test, expect } = require('@playwright/test')
+const { setupApiMock } = require('./helpers/mock-api')
+const { HARNESS_URL, waitForReaderRendered } = require('./helpers/reader')
+
+function silentWav(durationSeconds = 8, sampleRate = 8000) {
+  const sampleCount = durationSeconds * sampleRate
+  const dataLength = sampleCount * 2
+  const buffer = Buffer.alloc(44 + dataLength)
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataLength, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)
+  buffer.writeUInt16LE(1, 20)
+  buffer.writeUInt16LE(1, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * 2, 28)
+  buffer.writeUInt16LE(2, 32)
+  buffer.writeUInt16LE(16, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataLength, 40)
+  return buffer
+}
+
+const manifest = {
+  id: 7,
+  book_id: 101,
+  chapters: [{
+    id: 71,
+    number: 1,
+    title: '第一章 绯红',
+    source_key: 'index_split_002.html#filepos138679',
+    duration_ms: 8000,
+    audio_url: '/api/audiobooks/7/chapters/1/audio',
+    timeline_url: '/api/audiobooks/7/chapters/1/timeline',
+  }],
+}
+
+const timeline = {
+  format: 'voicebook-timeline',
+  version: 1,
+  chapter_number: 1,
+  duration_ms: 8000,
+  segments: [
+    {
+      id: 'seg-1',
+      index: 0,
+      start_ms: 0,
+      end_ms: 4000,
+      text: '好痛！',
+      locator: {
+        type: 'epub-dom-text',
+        href: 'index_split_002.html',
+        dom_path: 'body/p[3]',
+        start_char: 0,
+        end_char: 3,
+      },
+    },
+    {
+      id: 'seg-2',
+      index: 1,
+      start_ms: 4200,
+      end_ms: 7600,
+      text: '头好痛！',
+      locator: {
+        type: 'epub-dom-text',
+        href: 'index_split_002.html',
+        dom_path: 'body/p[4]',
+        start_char: 0,
+        end_char: 4,
+      },
+    },
+  ],
+}
+
+async function setupAudiobook(page) {
+  return setupApiMock(page, {
+    'GET /api/audiobooks/7/manifest': { err: 'ok', manifest, progress: null },
+    'GET /api/audiobooks/7/chapters/1/timeline': { err: 'ok', timeline },
+    'GET /api/audiobooks/7/chapters/1/audio': {
+      __contentType: 'audio/wav',
+      __headers: { 'Accept-Ranges': 'bytes' },
+      __body: silentWav(),
+    },
+    'POST /api/audiobooks/7/sessions': { err: 'ok', session_id: 'candle-e2e' },
+    'PATCH /api/audiobook-sessions/candle-e2e': { err: 'ok', version: 1 },
+    'POST /api/audiobook-sessions/candle-e2e': { err: 'ok' },
+  })
+}
+
+async function gotoAudiobookReader(page) {
+  await page.goto(`${HARNESS_URL}?audiobook=1`)
+  await page.getByRole('button', { name: '听书', exact: true }).waitFor({ state: 'visible' })
+  await waitForReaderRendered(page)
+}
+
+async function activeHighlight(page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll('#reader iframe')).map((frame) => {
+      const element = frame.contentDocument?.querySelector('[data-candle-audiobook-active]')
+      return element ? {
+        id: element.getAttribute('data-candle-audiobook-active'),
+        text: element.textContent,
+      } : null
+    }).find(Boolean) || null
+  })
+}
+
+test.beforeEach(async ({ page }) => {
+  await setupAudiobook(page)
+})
+
+test('播放时间轴会自动翻到对应正文并按句段高亮', async ({ page }) => {
+  await gotoAudiobookReader(page)
+  await page.getByRole('button', { name: '听书', exact: true }).click()
+
+  const player = page.getByTestId('candle-audiobook-player')
+  await expect(player).toContainText('第一章 绯红')
+  await page.getByRole('button', { name: '播放听书' }).click()
+
+  await expect(player).toContainText('好痛！')
+  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1', text: '好痛！' })
+})
+
+test('手动翻页暂停自动跟随，并可返回当前朗读句段', async ({ page }) => {
+  await gotoAudiobookReader(page)
+  await page.getByRole('button', { name: '听书', exact: true }).click()
+  await page.getByRole('button', { name: '播放听书' }).click()
+  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1' })
+
+  await page.keyboard.press('ArrowRight')
+  const returnButton = page.getByTestId('return-to-narration')
+  await expect(returnButton).toBeVisible()
+  await expect.poll(() => activeHighlight(page)).toBeNull()
+
+  await returnButton.click()
+  await expect(returnButton).toBeHidden()
+  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1' })
+})
+
+test('选中正文后可从对应时间轴片段开始听', async ({ page }) => {
+  await gotoAudiobookReader(page)
+
+  await page.evaluate(async () => {
+    const app = document.querySelector('#app').__vue_app__
+    const reader = app._instance.subTree.component.proxy
+    await reader.rendition.display('index_split_002.html#filepos138679')
+    let contents = null
+    reader.rendition.views().forEach((view) => {
+      if (view.section?.href?.includes('index_split_002')) contents = view.contents
+    })
+    const element = contents.document.querySelector('body > p:nth-of-type(4)')
+    const cfi = new window.ePub.CFI(element, contents.cfiBase)
+    reader.selected_location = {
+      toc: { href: 'index_split_002.html', label: '第一章 绯红' },
+      cfi,
+      contents,
+      segment_id: 1,
+    }
+    reader.toolbar_left = 20
+    reader.toolbar_top = 120
+  })
+
+  await page.getByRole('button', { name: '从这里听' }).click()
+  const player = page.getByTestId('candle-audiobook-player')
+  await expect(player).toBeVisible()
+  await expect(player).toContainText('头好痛！', { timeout: 5000 })
+  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-2', text: '头好痛！' })
+})

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -148,9 +148,7 @@ test('章节视图延迟注册时仍会重试高亮', async ({ page }) => {
 test('手动翻页暂停自动跟随，并可返回当前朗读句段', async ({ page }) => {
   await gotoAudiobookReader(page)
   await page.getByRole('button', { name: '听书', exact: true }).click()
-  await page.getByRole('button', { name: '播放听书' }).click()
-  await expectActiveHighlight(page, { id: 'seg-1' })
-  await page.getByRole('button', { name: '暂停听书' }).click()
+  await expect(page.getByTestId('candle-audiobook-player')).toContainText('好痛！', { timeout: 15000 })
 
   await page.keyboard.press('ArrowRight')
   const returnButton = page.getByTestId('return-to-narration')

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -2,7 +2,7 @@ const { test, expect } = require('@playwright/test')
 const { setupApiMock } = require('./helpers/mock-api')
 const { HARNESS_URL, waitForReaderRendered } = require('./helpers/reader')
 
-function silentWav(durationSeconds = 8, sampleRate = 8000) {
+function silentWav(durationSeconds = 12, sampleRate = 8000) {
   const sampleCount = durationSeconds * sampleRate
   const dataLength = sampleCount * 2
   const buffer = Buffer.alloc(44 + dataLength)
@@ -30,7 +30,7 @@ const manifest = {
     number: 1,
     title: '第一章 绯红',
     source_key: 'index_split_002.html#filepos138679',
-    duration_ms: 8000,
+    duration_ms: 12000,
     audio_url: '/api/audiobooks/7/chapters/1/audio',
     timeline_url: '/api/audiobooks/7/chapters/1/timeline',
   }],
@@ -40,13 +40,13 @@ const timeline = {
   format: 'voicebook-timeline',
   version: 1,
   chapter_number: 1,
-  duration_ms: 8000,
+  duration_ms: 12000,
   segments: [
     {
       id: 'seg-1',
       index: 0,
       start_ms: 0,
-      end_ms: 4000,
+      end_ms: 9000,
       text: '好痛！',
       locator: {
         type: 'epub-dom-text',
@@ -59,8 +59,8 @@ const timeline = {
     {
       id: 'seg-2',
       index: 1,
-      start_ms: 4200,
-      end_ms: 7600,
+      start_ms: 9200,
+      end_ms: 11600,
       text: '头好痛！',
       locator: {
         type: 'epub-dom-text',
@@ -119,6 +119,25 @@ test('播放时间轴会自动翻到对应正文并按句段高亮', async ({ pa
   await page.getByRole('button', { name: '播放听书' }).click()
 
   await expect(player).toContainText('好痛！')
+  await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1', text: '好痛！' })
+})
+
+test('章节视图延迟注册时仍会重试高亮', async ({ page }) => {
+  await gotoAudiobookReader(page)
+  await page.evaluate(() => {
+    const app = document.querySelector('#app').__vue_app__
+    const reader = app._instance.subTree.component.proxy
+    const display = reader.rendition.display.bind(reader.rendition)
+    reader.rendition.display = (...args) => {
+      window.setTimeout(() => void display(...args), 350)
+      return Promise.resolve()
+    }
+  })
+
+  await page.getByRole('button', { name: '听书', exact: true }).click()
+  await page.getByRole('button', { name: '播放听书' }).click()
+
+  await expect(page.getByTestId('candle-audiobook-player')).toContainText('好痛！')
   await expect.poll(() => activeHighlight(page)).toMatchObject({ id: 'seg-1', text: '好痛！' })
 })
 

--- a/tests/e2e/audiobook.spec.js
+++ b/tests/e2e/audiobook.spec.js
@@ -150,6 +150,7 @@ test('手动翻页暂停自动跟随，并可返回当前朗读句段', async ({
   await page.getByRole('button', { name: '听书', exact: true }).click()
   await page.getByRole('button', { name: '播放听书' }).click()
   await expectActiveHighlight(page, { id: 'seg-1' })
+  await page.getByRole('button', { name: '暂停听书' }).click()
 
   await page.keyboard.press('ArrowRight')
   const returnButton = page.getByTestId('return-to-narration')

--- a/tests/e2e/fixtures/reader-harness.html
+++ b/tests/e2e/fixtures/reader-harness.html
@@ -9,6 +9,7 @@
   <script src="/js/epub-v0.3.88.js"></script>
   <script type="module">
     import { Reader } from "/src/main.js"
+    const audiobookEnabled = new URLSearchParams(window.location.search).has('audiobook')
     // server 指向本地同源，使所有 /api/** 请求都走同源、便于 Playwright route mock；
     // book_url 用 .epub 压缩包，与生产从 talebook 服务取书一致；JSZip 就位后 headless 下可正常解压渲染。
     new Reader('#app', {
@@ -16,6 +17,10 @@
       themes_css: "/css/themes.css",
       server: window.location.origin,
       book_url: "/demo/book1.epub",
+      display_url: "",
+      book_id: 101,
+      audiobook_edition_id: audiobookEnabled ? 7 : null,
+      audiobook_manifest_url: audiobookEnabled ? '/api/audiobooks/7/manifest' : '',
     })
   </script>
 </head>

--- a/tests/e2e/helpers/mock-api.js
+++ b/tests/e2e/helpers/mock-api.js
@@ -54,6 +54,16 @@ async function setupApiMock(page, overrides = {}) {
       return
     }
 
+    if (body.__body !== undefined) {
+      await route.fulfill({
+        status: body.__status || 200,
+        contentType: body.__contentType || 'application/octet-stream',
+        headers: body.__headers || {},
+        body: body.__body,
+      })
+      return
+    }
+
     await route.fulfill({
       status: body.__status || 200,
       contentType: 'application/json',


### PR DESCRIPTION
## 变更
- 新增逐章 MP3 播放器、倍速、断点恢复和 Media Session
- 根据 voicebook 时间轴自动跳章、按句高亮，支持手动脱离与返回朗读位置
- 支持选中正文后从对应句段开始播放
- Reader 公共参数新增 book_id、audiobook_edition_id、audiobook_manifest_url
- 有声书 API 固定请求当前书籍站点，不影响既有公共评论服务

## 验证
- npm run test:e2e：37 passed
- npm run build：通过
- 新增/直接修改文件 ESLint：通过